### PR TITLE
[PR] Changes for PHPCS, naming

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-WSUWP Plugin Skeleton
+WSUWP Extended WordPress SEO
 
 Copyright 2016 by Washington State University
 
@@ -363,4 +363,4 @@ WRITTEN OFFER
 The source code for any program binaries or compressed scripts that are
 included with WSU Content Visibility can be freely obtained at the following URL:
 
-	https://github.com/washingtonstateuniversity/WSUWP-Plugin-Skeleton/
+	https://github.com/washingtonstateuniversity/wsuwp-extended-wordpress-seo/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# WSUWP-Extended-WordPress-SEO
-A WordPress plugin to apply modifications to Yoast SEO
+# WSUWP Extended WordPress SEO
+
+A WordPress plugin to apply modifications to Yoast's WordPress SEO.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "washingtonstateuniversity/wsuwp-plugin-skeleton",
+  "name": "washingtonstateuniversity/wsuwp-extended-wordpress-seo",
   "authors": [
     {
       "name": "Washington State University"

--- a/includes/class-wsu-seo.php
+++ b/includes/class-wsu-seo.php
@@ -56,6 +56,8 @@ class WSUWP_Extend_WP_SEO {
 
 	/**
 	 * Enqueue script for modifying the SEO metabox for post types.
+	 *
+	 * @param string @hook The hook representing the admin page being viewed.
 	 */
 	function wpseo_metabox( $hook ) {
 		if ( ! in_array( $hook, array( 'edit.php', 'post.php', 'post-new.php' ), true ) ) {

--- a/includes/class-wsu-seo.php
+++ b/includes/class-wsu-seo.php
@@ -62,7 +62,7 @@ class WSUWP_Extend_WP_SEO {
 			return;
 		}
 
-		wp_enqueue_script( 'spine-wpseo-mb', plugins_url( '/js/wsu-wpseo-metabox.js', __FILE__ ), array('jquery'), '0.1', true );
+		wp_enqueue_script( 'spine-wpseo-mb', plugins_url( '/js/wsu-wpseo-metabox.js', __FILE__ ), array( 'jquery' ), '0.1', true );
 	}
 
 	/**
@@ -118,5 +118,4 @@ class WSUWP_Extend_WP_SEO {
 		}
 		return $title;
 	}
-
 }

--- a/includes/class-wsu-seo.php
+++ b/includes/class-wsu-seo.php
@@ -51,7 +51,7 @@ class WSUWP_Extend_WP_SEO {
 	 * Remove `Titles & Metas` from the menu.
 	 */
 	public function remove_wpseo_titles_page() {
-		$page = remove_submenu_page( 'wpseo_dashboard', 'wpseo_titles' );
+		remove_submenu_page( 'wpseo_dashboard', 'wpseo_titles' );
 	}
 
 	/**

--- a/includes/class-wsu-seo.php
+++ b/includes/class-wsu-seo.php
@@ -58,7 +58,7 @@ class WSUWP_Extend_WP_SEO {
 	 * Enqueue script for modifying the SEO metabox for post types.
 	 */
 	function wpseo_metabox( $hook ) {
-		if ( ! in_array( $hook, array( 'edit.php', 'post.php', 'post-new.php' ) ) ) {
+		if ( ! in_array( $hook, array( 'edit.php', 'post.php', 'post-new.php' ), true ) ) {
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "wsuwp-plugin-skeleton",
+  "name": "wsuwp-extended-wordpress-seo",
   "version": "0.0.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/washingtonstateuniversity/wsuwp-plugin-skeleton"
+    "url": "https://github.com/washingtonstateuniversity/wsuwp-extended-wordpress-seo"
   },
   "devDependencies": {
     "grunt": "~0.4.5",

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WSUWP Plugin Skeleton">
-    <description>Sniffs for the coding standards of the WSUWP Plugin Skeleton plugin</description>
+<ruleset name="WSUWP Extended WordPress SEO">
+    <description>Sniffs for the coding standards of the WSUWP Extended WordPress SEO plugin</description>
 
     <rule ref="WordPress-Extra">
         <exclude name="WordPress.NamingConventions.ValidFunctionName" />

--- a/wsu-extended-wordpress-seo.php
+++ b/wsu-extended-wordpress-seo.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: WSU Extended WordPress SEO
+Plugin Name: WSUWP Extended WordPress SEO
 Version: 0.0.1
 Plugin URI: https://web.wsu.edu/
 Description: Modifies default functionality in WordPress SEO.

--- a/wsu-extended-wordpress-seo.php
+++ b/wsu-extended-wordpress-seo.php
@@ -1,9 +1,9 @@
 <?php
 /*
-Plugin Name: WSU Extended Yoast SEO
+Plugin Name: WSU Extended WordPress SEO
 Version: 0.0.1
 Plugin URI: https://web.wsu.edu/
-Description: Modifies default functionality in Yoast SEO.
+Description: Modifies default functionality in WordPress SEO.
 Author: washingtonstateuniversity, philcable
 Author URI: https://web.wsu.edu/
 */


### PR DESCRIPTION
- Fixed a couple spacing issues after `grunt phpcs` pointed them out.
- Updated the naming throughout to follow "WSUWP Extended WordPress SEO"
