### PR TITLE
[PR] Only filter the title filer if the Spine theme is available

### DIFF
--- a/includes/class-wsu-seo.php
+++ b/includes/class-wsu-seo.php
@@ -98,7 +98,11 @@ class WSUWP_Extend_WP_SEO {
 	/**
 	 * Filter OG and Twitter title meta tag values and get_document_title function.
 	 */
-	public function meta_titles_filter() {
+	public function meta_titles_filter( $title ) {
+		if ( ! function_exists( 'spine_get_title' ) ) {
+			return $title;
+		}
+
 		return spine_get_title();
 	}
 


### PR DESCRIPTION
This was causing a fatal error on the platform - either on a site that didn't have the Spine Parent Theme enabled or firing before `spine_get_title()` was available.
